### PR TITLE
Fixed build debugging command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ defaults write com.apple.iphonesimulator AllowFullscreenMode -bool YES
 Creates an XCBuildData folder in `~/Library/Developer/Xcode/DerivedData/<your target>/Build/Intermediates.noindex/` which contains debugging info for xcodebuild.
 
 ```sh
-defaults write com.apple.dt.XCBuild YES
+defaults write com.apple.dt.XCBuild -bool YES
 ```


### PR DESCRIPTION
Fixed an issue where `-bool` was missing on the Enable Build Debugging section command