### PR TITLE
Add a warning for disabling indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Where `sysctl -n hw.ncpu` gives you the number of CPU threads.
 
 ### Enable/Disable indexing
 
+Keep in mind that disabling indexing will disable `refactor` code action so you probably won't be able to generate protocol conformances or memberwise initializers
+
 ##### Enable indexing
 
 ```sh


### PR DESCRIPTION
I've struggled with this issue for quite a while, and couldn't find a solution on the internet (even though I found this repo, it didn't help at least at first), but after a while, I noticed that I semi-accidentally disabled indexing (it was in the `.dotfiles` I used to set up my new environment) and enabling it solved the issue.

This warning might help not just users of this repo but also strangers from the internet like me, so they could discover such a repo too 😅